### PR TITLE
occurrence search is broken

### DIFF
--- a/src/occurrence.jl
+++ b/src/occurrence.jl
@@ -238,7 +238,7 @@ $(_keydocs(OCCURRENCE_KEY_DESC, keys(OCCURRENCE_KEY_DESC)))
 """
 function occurrence_search end
 function occurrence_search(species::Species; kw...)
-    occurrence_search(; q=_bestquery(species)[1][2], kw...)
+    occurrence_search(; _bestquery(species)..., kw...)
 end
 occurrence_search(q; kw...) = occurrence_search(; q, kw...)
 function occurrence_search(; returntype=nothing, limit=20, offset=0, kw...)
@@ -246,7 +246,7 @@ function occurrence_search(; returntype=nothing, limit=20, offset=0, kw...)
         allowed_rt = keys(OCCURRENCE_SEARCH_RETURNTYPE)
         returntype in allowed_rt || throw(ArgumentError("$returntype not in $allowed_rt"))
         url = _joinurl(OCCURRENCE_SEARCH_URL, returntype)
-        query = _format_query((; limit, kw...), keys(OCCURRENCE_KEY_DESC))
+        query = _format_query((; limit, q = kw[1]), keys(OCCURRENCE_KEY_DESC))
         request = HTTP.get(url; query)
         return _handle_request(JSON3.read, request)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -90,7 +90,7 @@ end
     results = occurrence_search(sp)
     oc1 = results[1]
     @test oc1 isa GBIF2.Occurrence
-    @test oc1.genus == "Hippophae"
+    @test all(results.species .== "Coracina newtoni")
     @testset "occurrence tables write to CSV" begin
         CSV.write("occurence_test.csv", results)
         df = CSV.read("occurence_test.csv", DataFrame)
@@ -110,7 +110,7 @@ end
         end
     end
     @test_throws ArgumentError species_search("Lalage newtoni"; not_a_keyword=2)
-    results = occurrence_search(sp; returntype=:catalogNumber)
+    results = occurrence_search(returntype=:occurrenceId, q = "https://www.inaturalist.org/observations")
     @test results isa AbstractVector{<:String} # TODO maybe it should be specialised to Int
     results = occurrence_search("")
 end


### PR DESCRIPTION
I found a pretty serious bug in occurence_search, which means it currently returns the wrong results.

Rather than searching on specific keywords, occurrence_search currently searches just the `q` field, which means all fields are searched, and the wrong records are returned.

I don't know if this was triggered by some change in the GBIF API, but the mistake was baked into the tests as well (Lalage newtoni does not belong to the genus Hippophae).

I fixed it so that the default occurrence_search works again and now passes the keywords to the API query correctly.

For cases where returntype is something else than nothing, we cannot pass any other keywords than `q`. Right now I just made it so that the first keywords argument is passed as `q`, but I don't know what the proper fix is. Maybe it should be two separate functions?